### PR TITLE
Markdown edits

### DIFF
--- a/markdown/ISD-NATIONAL-STATS-REPORT.Rmd
+++ b/markdown/ISD-NATIONAL-STATS-REPORT.Rmd
@@ -59,7 +59,16 @@ trend_data <- read_csv(here("data",
                             "output",
                             paste0(pub_date(end_date = end_date,
                                             pub = "current"),
-                                   "_trends-data-level2.csv"))) %>%
+                                   "_trends-data-level2.csv")),
+                            col_types = cols(
+                         quarter = col_double(),
+                         quarter_short = col_character(),
+                         quarter_full = col_character()
+                       )) %>%
+  filter(time_period == "Quarter") %>% 
+  select(hb, location, location_name, agg_label, quarter, quarter_short,
+         quarter_full, sub_grp, label, scot_deaths,	scot_pats,
+         completeness_date,	deaths,	pats,	crd_rate) %>% 
   filter(!is.na(label)) %>% 
   arrange(hb, label, quarter) 
 

--- a/markdown/ISD-NATIONAL-STATS-REPORT.Rmd
+++ b/markdown/ISD-NATIONAL-STATS-REPORT.Rmd
@@ -419,10 +419,10 @@ ggsave("Chart_10.png", plot = chart_10, width = 17.49, height = 9.03,
 
 ```{r URL list, echo = FALSE, message= FALSE, warning = FALSE, error = FALSE}
 url_list <- data.frame(a = c(1, 2, 3, 4), 
-             url = c(paste0("http://www.isdscotland.org/Health-Topics/Quality-Indicators/Publications/", pub_date(end_date, "current"),"/", pub_date(end_date, "current"),"-Table1-HSMR.xlsx"), 
-                     paste0("http://www.isdscotland.org/Health-Topics/Quality-Indicators/Publications/", pub_date(end_date, "current"),"/", pub_date(end_date, "current"),"-Table2-Crude-Mortality-Subgroups.xlsx"), 
-                     paste0("http://www.isdscotland.org/Health-Topics/Quality-Indicators/Publications/", pub_date(end_date, "current"),"/", pub_date(end_date, "current"),"-Table3-Crude-Mortality-population-based-and-30-day-from-discharge.xlsx"), 
-                     paste0("http://www.isdscotland.org/Health-Topics/Quality-Indicators/Publications/",pub_date(end_date, "current"),"/Table4.xls")), 
+             url = c(paste0("https://beta.isdscotland.org/find-publications-and-data/health-services/hospital-care/hospital-standardised-mortality-ratios/", format(pub_date(end_date = end_date, pub = "current"), "%d_%B_%Y"),"/"), 
+                     paste0("https://beta.isdscotland.org/find-publications-and-data/health-services/hospital-care/hospital-standardised-mortality-ratios/", format(pub_date(end_date = end_date, pub = "current"), "%d_%B_%Y"),"/"), 
+                     paste0("https://beta.isdscotland.org/find-publications-and-data/health-services/hospital-care/hospital-standardised-mortality-ratios/", format(pub_date(end_date = end_date, pub = "current"), "%d_%B_%Y"),"/"), 
+                     paste0("https://beta.isdscotland.org/find-publications-and-data/health-services/hospital-care/hospital-standardised-mortality-ratios/", format(pub_date(end_date = end_date, pub = "current"), "%d_%B_%Y"),"/")), 
              stringsAsFactors = FALSE)
 
 ```
@@ -732,7 +732,9 @@ Chart 8 shows the proportion of deaths within 30 days of admission by place of d
 ![Trend chart showing proportion of deaths by place of admission for the last five years](Chart_8.png)</div>
 
 <Div custom-style = "Heading 2_pgbrk">Hospital and NHS Board Level</div>
-HSMR data are provided by ISD to allow an individual hospital to monitor its mortality in comparison to the National average. The process is not designed to compare hospitals. Trends in crude mortality are provided to allow individual hospitals to monitor variation over time.  
+HSMR data are provided by ISD to allow an individual hospital to monitor its mortality in comparison to the National average. The process is not designed to compare hospitals. Trends in crude mortality are provided to allow individual hospitals to monitor variation over time. 
+
+**NHS Fife**: In order to reflect current service configuration, an HSMR is not reported on separately for Queen Margaret Hospital as this site does not include any acute wards.
 
 ### Combined Institutions
 In order to reflect current service configuration, some hospitals are presented as combined institutions for the purposes of these reports. This applies to the following NHS Boards.  
@@ -825,13 +827,6 @@ The next update, reporting on admissions to `r completeness_next`, will be publi
     knitr::kable(glossary, col.names = NULL, align = c('l','l'))
 ```
 
-####### List of Tables
-<br>
-```{r kable_ListOfTables, echo = FALSE}
-
-  knitr::kable(table_list, col.names = c("**File Name**","**File and Size**"))
-
-```
 
 <Div custom-style = "Heading 2_pgbrk">Contact</div>
 **Robyn Munro, Principal Information Analyst**  
@@ -859,7 +854,7 @@ The next release of this publication will be `r format(pub_date(end_date = end_d
 <br>
 
 ## Rate this publication
-Please [provide feedback](http://www.isdscotland.org/Health-Topics/HEALTHTOPIC/Publications/rate-this-publication.asp?ID=XXXX) on this publication to help us improve our services.
+If you wish to provide feedback on this publication to help us improve our service, please email NSS.isdQualityIndicators@nhs.net.
 
 <Div custom-style = "Heading 2_pgbrk">Appendices</div>
 ### Appendix 1 – Background information

--- a/markdown/ISD-NATIONAL-STATS-REPORT.Rmd
+++ b/markdown/ISD-NATIONAL-STATS-REPORT.Rmd
@@ -832,19 +832,18 @@ The next update, reporting on admissions to `r completeness_next`, will be publi
 **Robyn Munro, Principal Information Analyst**  
 Quality Indicators  
 Phone:  0131 275 6967  
-Email:  Robyn.Munro@nhs.net
 
 **David Caldwell, Senior Information Analyst**  
 Quality Indicators  
 Phone:  0131 275 7421  
-Email:  David.Caldwell1@nhs.net
 
 **Lucinda Lawrie, Information Analyst**  
 Quality Indicators  
 Phone:  0131 275 7929  
-Email:  Lucinda.Lawrie1@nhs.net
 
 <br>
+
+**Email:** NSS.isdQualityIndicators@nhs.net
 
 ## Further Information
 Further Information can be found on the [ISD website](http://www.isdscotland.org/).  

--- a/markdown/ISD-NATIONAL-STATS-REPORT.Rmd
+++ b/markdown/ISD-NATIONAL-STATS-REPORT.Rmd
@@ -66,9 +66,7 @@ trend_data <- read_csv(here("data",
                          quarter_full = col_character()
                        )) %>%
   filter(time_period == "Quarter") %>% 
-  select(hb, location, location_name, agg_label, quarter, quarter_short,
-         quarter_full, sub_grp, label, scot_deaths,	scot_pats,
-         completeness_date,	deaths,	pats,	crd_rate) %>% 
+  select(-(month), -(month_label), -(time_period)) %>% 
   filter(!is.na(label)) %>% 
   arrange(hb, label, quarter) 
 

--- a/markdown/ISD-NATIONAL-STATS-SUMMARY.Rmd
+++ b/markdown/ISD-NATIONAL-STATS-SUMMARY.Rmd
@@ -52,9 +52,9 @@ smr_data          <- read_csv(here("data",
                           TRUE ~ "0"))
 
 #Create contact information
-contact1 <- c("**Robyn Munro**", "Principal Information Analyst", "0131 275 6967", "Robyn.Munro@nhs.net")
-contact2 <- c("**David Caldwell**", "Senior Information Analyst", "0131 275 7421", "David.Caldwell1@nhs.net")
-contact3 <- c("**Lucinda Lawrie**", "Information Analyst", "0131 275 7929", "Lucinda.Lawrie1@nhs.net")
+contact1 <- c("**Robyn Munro**", "Principal Information Analyst", "0131 275 6967")
+contact2 <- c("**David Caldwell**", "Senior Information Analyst", "0131 275 7421")
+contact3 <- c("**Lucinda Lawrie**", "Information Analyst", "0131 275 7929")
 
 contact <- data.frame(contact1, contact2, contact3)
 ```
@@ -100,6 +100,7 @@ If the number of deaths is more than predicted this does not necessarily mean th
 ```{r, echo = FALSE}
     knitr::kable(contact, col.names=NULL)
 ```
+**Email:** NSS.isdQualityIndicators@nhs.net
 
 ### Further Information
 

--- a/markdown/ISD-NATIONAL-STATS-SUMMARY.Rmd
+++ b/markdown/ISD-NATIONAL-STATS-SUMMARY.Rmd
@@ -103,7 +103,7 @@ If the number of deaths is more than predicted this does not necessarily mean th
 
 ### Further Information
 
-The data from this publication is available to download from our [web page](http://www.isdscotland.org/Health-Topics/Quality-Indicators/Publications/data-tables2017.asp). 
+The data from this publication is available to download from this page. 
 A [Technical Document](http://www.isdscotland.org/Health-Topics/Quality-Indicators/HSMR/Methodology/_docs/HSMR_2016_technical_specification.pdf) is available on how HSMR is calculated. A [Frequently Asked Questions](http://www.isdscotland.org/Health-Topics/Quality-Indicators/HSMR/FAQ/) document is also available. For more information on HSMR see [HSMR section of our website](http://www.isdscotland.org/Health-Topics/Quality-Indicators/HSMR/). **HSMRs published from August 2019 onwards cannot be compared to prior releases using a different methodology**. For more information see [Research and Development](https://www.isdscotland.org/Health-Topics/Quality-Indicators/HSMR/Research-and-Development/).
 
 


### PR DESCRIPTION
I've updated the report and summary documents in line with the new publication guidance. For ease I've left the URL list references the same in the body of the report but changed each of the 4 URLs to be the same. I thought if anything changed further down the line (e.g. we are told we can link directly to the data tables) then it would be easier to do it if the references remain as they are.

Let me know if you think there is anything I've missed :)
